### PR TITLE
For Dagger implementation, update default module annotation with `injects={FXMLLoader.class}`

### DIFF
--- a/dagger/src/main/java/com/gluonhq/ignite/dagger/DaggerContext.java
+++ b/dagger/src/main/java/com/gluonhq/ignite/dagger/DaggerContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Gluon
+ * Copyright (c) 2020, 2021, Gluon
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/dagger/src/main/java/com/gluonhq/ignite/dagger/DaggerContext.java
+++ b/dagger/src/main/java/com/gluonhq/ignite/dagger/DaggerContext.java
@@ -84,7 +84,7 @@ public class DaggerContext implements DIContext {
         injectMembers(contextRoot);
     }
 
-    @Module(library = true, complete = false)
+    @Module(library = true, injects = {FXMLLoader.class}, complete = false)
     class FXModule  {
 
         @Provides

--- a/micronaut/src/main/java/com/gluonhq/ignite/micronaut/FXMLRootProvider.java
+++ b/micronaut/src/main/java/com/gluonhq/ignite/micronaut/FXMLRootProvider.java
@@ -46,12 +46,12 @@ public class FXMLRootProvider {
     private static final Logger LOG = LoggerFactory.getLogger(FXMLRootProvider.class);
 
     @Inject private ApplicationContext ctx;
-    @Inject FXMLLoaderFactory loaderFactory;
+    @Inject private FXMLLoaderFactory loaderFactory;
 
-    public Node getRootByClass(@NotBlank Class<?> viewClass) {
+    public <T extends Node> T getRootByClass(@NotBlank Class<?> viewClass) {
         String viewPath = getViewPath(viewClass);
         String fxml = withExt(viewPath, "fxml");
-        Node node;
+        T node;
 
         try {
             LOG.info("Attempting to load " + fxml);

--- a/micronaut/src/main/java/com/gluonhq/ignite/micronaut/view/FXMLView.java
+++ b/micronaut/src/main/java/com/gluonhq/ignite/micronaut/view/FXMLView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Gluon
+ * Copyright (c) 2020, 2021, Gluon
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/micronaut/src/main/java/com/gluonhq/ignite/micronaut/view/FXMLView.java
+++ b/micronaut/src/main/java/com/gluonhq/ignite/micronaut/view/FXMLView.java
@@ -61,9 +61,8 @@ public class FXMLView<T extends Parent> implements View<T> {
     }
 
     @PostConstruct
-    @SuppressWarnings("unchecked")
     private void init() {
-        rootProperty.set((T) rootProvider.getRootByClass(this.getClass()));
+        rootProperty.set( rootProvider.getRootByClass(this.getClass()));
     }
 
 }


### PR DESCRIPTION
Currently developer has to add the same to their module definition to make FXMLLoader injection work. 
Also, better definition of FXMLView root node type, removes compiler warnings and improves API
