### PR TITLE
Updating to micronaut 2.5.13

### DIFF
--- a/micronaut/build.gradle
+++ b/micronaut/build.gradle
@@ -1,6 +1,6 @@
 ext {
     description = 'Creates a common abstraction over Micronaut'
-    micronautVersion = "2.1.3"
+    micronautVersion = "2.5.13"
 }
 
 dependencies {
@@ -9,7 +9,6 @@ dependencies {
     implementation "io.micronaut:micronaut-inject:$micronautVersion"
     implementation("io.micronaut:micronaut-validation:$micronautVersion")
     implementation("io.micronaut:micronaut-runtime:$micronautVersion")
-    implementation "javax.annotation:javax.annotation-api:1.3.2"
     runtimeOnly("ch.qos.logback:logback-classic:1.2.3")
 
     compile project(':common')

--- a/micronaut/src/main/java/com/gluonhq/ignite/micronaut/FXMLRootProvider.java
+++ b/micronaut/src/main/java/com/gluonhq/ignite/micronaut/FXMLRootProvider.java
@@ -72,11 +72,11 @@ public class FXMLRootProvider {
         return node;
     }
 
-    private String getViewPath(@NotBlank Class<?> cls) {
+    private String getViewPath(Class<?> cls) {
         return cls.getName().replace('.', '/');
     }
 
-    private String withExt( @NotBlank String viewName, @NotBlank String extName ) {
+    private String withExt(String viewName, String extName ) {
         String ext = extName.startsWith(".")? extName: "." + extName;
         return String.format("/%s%s", viewName, ext);
     }

--- a/micronaut/src/main/java/com/gluonhq/ignite/micronaut/OnFXThreadInterceptor.java
+++ b/micronaut/src/main/java/com/gluonhq/ignite/micronaut/OnFXThreadInterceptor.java
@@ -27,6 +27,7 @@
  */
 package com.gluonhq.ignite.micronaut;
 
+import io.micronaut.aop.InterceptorBean;
 import io.micronaut.aop.MethodInterceptor;
 import io.micronaut.aop.MethodInvocationContext;
 import javafx.application.Platform;
@@ -34,6 +35,7 @@ import javafx.application.Platform;
 import javax.inject.Singleton;
 
 @Singleton
+@InterceptorBean(OnFXThread.class)
 class OnFXThreadInterceptor implements MethodInterceptor<Object, Object> {
     @Override
     public Object intercept(MethodInvocationContext<Object, Object> context) {

--- a/micronaut/src/main/java/com/gluonhq/ignite/micronaut/view/FXMLView.java
+++ b/micronaut/src/main/java/com/gluonhq/ignite/micronaut/view/FXMLView.java
@@ -28,8 +28,6 @@
 package com.gluonhq.ignite.micronaut.view;
 
 import com.gluonhq.ignite.micronaut.FXMLRootProvider;
-import com.gluonhq.ignite.micronaut.OnFXThread;
-import io.micronaut.aop.InterceptorBean;
 import javafx.beans.property.ReadOnlyObjectProperty;
 import javafx.beans.property.ReadOnlyObjectWrapper;
 import javafx.scene.Parent;

--- a/micronaut/src/main/java/com/gluonhq/ignite/micronaut/view/FXMLView.java
+++ b/micronaut/src/main/java/com/gluonhq/ignite/micronaut/view/FXMLView.java
@@ -28,6 +28,8 @@
 package com.gluonhq.ignite.micronaut.view;
 
 import com.gluonhq.ignite.micronaut.FXMLRootProvider;
+import com.gluonhq.ignite.micronaut.OnFXThread;
+import io.micronaut.aop.InterceptorBean;
 import javafx.beans.property.ReadOnlyObjectProperty;
 import javafx.beans.property.ReadOnlyObjectWrapper;
 import javafx.scene.Parent;


### PR DESCRIPTION
- Update micronaut to 2.5.13
- The `OnFXThreadInterceptor` requires `@InterceptorBean` or it would fail to create proper interceptor
- Removed some validation `@NotNull` annotations on `FXMLRootProvider` that were redundant and causing issue with compiler, because they were defined on final or private methods.